### PR TITLE
Fix to compatible with solidity 5

### DIFF
--- a/contracts/HashedTimelock.sol
+++ b/contracts/HashedTimelock.sol
@@ -1,5 +1,4 @@
-pragma solidity ^0.4.24;
-pragma experimental "v0.5.0";
+pragma solidity ^0.5.0;
 
 /**
  * @title Hashed Timelock Contracts (HTLCs) on Ethereum ETH.
@@ -20,7 +19,7 @@ pragma experimental "v0.5.0";
  *      back with this function.
  */
 contract HashedTimelock {
-    
+
     event LogHTLCNew(
         bytes32 indexed contractId,
         address indexed sender,
@@ -33,8 +32,8 @@ contract HashedTimelock {
     event LogHTLCRefund(bytes32 indexed contractId);
 
     struct LockContract {
-        address sender;
-        address receiver;
+        address payable sender;
+        address payable receiver;
         uint amount;
         bytes32 hashlock; // sha-2 sha256 hash
         uint timelock; // UNIX timestamp seconds - locked UNTIL this time
@@ -92,7 +91,7 @@ contract HashedTimelock {
      * @return contractId Id of the new HTLC. This is needed for subsequent 
      *                    calls.
      */
-    function newContract(address _receiver, bytes32 _hashlock, uint _timelock)
+    function newContract(address payable _receiver, bytes32 _hashlock, uint _timelock)
         external
         payable
         fundsSent
@@ -187,6 +186,7 @@ contract HashedTimelock {
     function getContract(bytes32 _contractId)
         public
         view
+        contractExists(_contractId)
         returns (
             address sender,
             address receiver,
@@ -198,8 +198,6 @@ contract HashedTimelock {
             bytes32 preimage
         )
     {
-        if (haveContract(_contractId) == false)
-            return;
         LockContract storage c = contracts[_contractId];
         return (c.sender, c.receiver, c.amount, c.hashlock, c.timelock,
                 c.withdrawn, c.refunded, c.preimage);

--- a/contracts/HashedTimelock.sol
+++ b/contracts/HashedTimelock.sol
@@ -186,7 +186,6 @@ contract HashedTimelock {
     function getContract(bytes32 _contractId)
         public
         view
-        contractExists(_contractId)
         returns (
             address sender,
             address receiver,
@@ -198,6 +197,8 @@ contract HashedTimelock {
             bytes32 preimage
         )
     {
+        if (haveContract(_contractId) == false)
+            return (address(0), address(0), 0, 0, 0, false, false, 0);
         LockContract storage c = contracts[_contractId];
         return (c.sender, c.receiver, c.amount, c.hashlock, c.timelock,
                 c.withdrawn, c.refunded, c.preimage);

--- a/contracts/HashedTimelockERC20.sol
+++ b/contracts/HashedTimelockERC20.sol
@@ -1,5 +1,4 @@
-pragma solidity ^0.4.24;
-pragma experimental "v0.5.0";
+pragma solidity ^0.5.0;
 
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 
@@ -51,7 +50,7 @@ contract HashedTimelockERC20 {
     modifier tokensTransferable(address _token, address _sender, uint _amount) {
         require(_amount > 0, "token amount must be > 0");
         require(
-            ERC20(_token).allowance(_sender, this) >= _amount,
+            ERC20(_token).allowance(_sender, address(this)) >= _amount,
             "token allowance must be >= amount"
         );
         _;
@@ -136,9 +135,9 @@ contract HashedTimelockERC20 {
             revert();
 
         // This contract becomes the temporary owner of the tokens
-        if (!ERC20(_tokenContract).transferFrom(msg.sender, this, _amount))
+        if (!ERC20(_tokenContract).transferFrom(msg.sender, address(this), _amount))
             revert();
-            
+
         contracts[contractId] = LockContract(
             msg.sender,
             _receiver,
@@ -213,6 +212,7 @@ contract HashedTimelockERC20 {
     function getContract(bytes32 _contractId)
         public
         view
+        contractExists(_contractId)
         returns (
             address sender,
             address receiver,
@@ -225,8 +225,6 @@ contract HashedTimelockERC20 {
             bytes32 preimage
         )
     {
-        if (haveContract(_contractId) == false)
-            return;
         LockContract storage c = contracts[_contractId];
         return (
             c.sender,

--- a/contracts/HashedTimelockERC20.sol
+++ b/contracts/HashedTimelockERC20.sol
@@ -212,7 +212,6 @@ contract HashedTimelockERC20 {
     function getContract(bytes32 _contractId)
         public
         view
-        contractExists(_contractId)
         returns (
             address sender,
             address receiver,
@@ -225,6 +224,8 @@ contract HashedTimelockERC20 {
             bytes32 preimage
         )
     {
+        if (haveContract(_contractId) == false)
+            return (address(0), address(0), address(0), 0, 0, 0, false, false, 0);
         LockContract storage c = contracts[_contractId];
         return (
             c.sender,

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.5.0;
 
 contract Migrations {
   address public owner;

--- a/package-lock.json
+++ b/package-lock.json
@@ -783,9 +783,9 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "openzeppelin-solidity": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-1.9.0.tgz",
-      "integrity": "sha512-MGI8clDbjrfWUg90AM82O+CHOaabtE2u9HyaUhBMKfWdIaO1urRUIgXIrEuloLvFEBHb5rtcgTARb5DkhUB4KQ=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.1.2.tgz",
+      "integrity": "sha512-1ggh+AZFpMAgGfgnVMQ8dwYawjD2QN4xuWkQS4FUbeUz1fnCKJpguUl2cyadyfDYjBq1XJ6MA6VkzYpTZtJMqw=="
     },
     "os-homedir": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "babel-register": "^6.26.0",
-    "openzeppelin-solidity": "^1.9.0"
+    "openzeppelin-solidity": "^2.1.2"
   },
   "devDependencies": {
     "bluebird": "^3.5.1"

--- a/test/helper/ASEANToken.sol
+++ b/test/helper/ASEANToken.sol
@@ -1,16 +1,16 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.5.0;
 
-import "openzeppelin-solidity/contracts/token/ERC20/StandardToken.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 
 /**
  * A basic token for testing the HashedTimelockERC20.
  */
-contract ASEANToken is StandardToken {
+contract ASEANToken is ERC20 {
     string public constant name = "ASEAN Token";
     string public constant symbol = "ASEAN";
     uint8 public constant decimals = 18;
-    
-    constructor(uint _initialBalance) public {
-        balances[msg.sender] = _initialBalance;
+
+    constructor(uint256 _initialBalance) public {
+        _mint(msg.sender, _initialBalance);
     }
 }

--- a/test/helper/assert.js
+++ b/test/helper/assert.js
@@ -1,8 +1,12 @@
 if (!global.assert) global.assert = require('chai').assert
 
 const assertEqualBN = (actual, expected, msg = 'numbers not equal') => {
+  if (!web3.utils.isBN(actual))
+    actual = web3.utils.toBN(actual)
+  if (!web3.utils.isBN(expected))
+    expected = web3.utils.toBN(expected)
   assert.isTrue(
-    actual.equals(expected),
+    actual.eq(expected),
     `
 \tmsg: ${msg}
 \tactual: ${actual.toString()}

--- a/test/helper/utils.js
+++ b/test/helper/utils.js
@@ -26,8 +26,8 @@ const newSecretHashPair = () => {
 
 const nowSeconds = () => Math.floor(Date.now() / 1000)
 
-const gasPrice = 100000000000 // truffle fixed gas price
-const txGas = txReceipt => txReceipt.receipt.gasUsed * gasPrice
+const defaultGasPrice = 100000000000 // truffle fixed gas price
+const txGas = (txReceipt, gasPrice = defaultGasPrice) => web3.utils.toBN(txReceipt.receipt.gasUsed * gasPrice)
 const txLoggedArgs = txReceipt => txReceipt.logs[0].args
 const txContractId = txReceipt => txLoggedArgs(txReceipt).contractId
 
@@ -58,8 +58,11 @@ const htlcERC20ArrayToObj = c => {
   }
 }
 
+const getBalance = async (address) => web3.utils.toBN(await web3.eth.getBalance(address))
+
 export {
   bufToStr,
+  getBalance,
   htlcArrayToObj,
   htlcERC20ArrayToObj,
   isSha256Hash,


### PR DESCRIPTION
Solidity 5 introduces some breaks like new type `address payable` not implicitly converted to `address`.
This PR fixes incompatible codes so as to be compiled with the latest solidity. (tested with solc@0.5.0)