### PR TITLE
Fix test errors

### DIFF
--- a/test/htlcERC20.js
+++ b/test/htlcERC20.js
@@ -128,12 +128,13 @@ contract('HashedTimelockERC20', accounts => {
       'tokens not transfered to htlc contract'
     )
 
+    await token.approve(htlc.address, tokenAmount, {from: sender})
     // now attempt to create another with the exact same parameters
     await newContractExpectFailure(
       'expected failure due to duplicate contract details',
       {
-        timelock,
-        hashlock,
+        timelock: timelock,
+        hashlock: hashlock,
       }
     )
   })
@@ -306,12 +307,13 @@ contract('HashedTimelockERC20', accounts => {
       receiverAddr = receiver,
       amount = tokenAmount,
       timelock = timeLock1Hour,
+      hashlock = newSecretHashPair().hash
     } = {}
   ) => {
     try {
       await htlc.newContract(
         receiverAddr,
-        newSecretHashPair().hash,
+        hashlock,
         timelock,
         token.address,
         amount,

--- a/test/htlcERC20.js
+++ b/test/htlcERC20.js
@@ -153,7 +153,7 @@ contract('HashedTimelockERC20', accounts => {
     await assertTokenBal(
       receiver,
       tokenAmount,
-      `receiver doesn't not own ${tokenAmount} tokens`
+      `receiver doesn't own ${tokenAmount} tokens`
     )
 
     const contractArr = await htlc.getContract.call(contractId)


### PR DESCRIPTION
The test for duplicate contract request in htlcERC20 raises assert due to no allowance of token for second contract instead of same contractId. This behavior differs from the intended negative test. Moreover, helper function `newContractExpectFailure` doesn't pass argument `hashlock`, so that test can't create the second contract identical to the first one.